### PR TITLE
fix: scroll-margin-top so sticky nav doesn't hide section headings

### DIFF
--- a/static/ai-game-proto.html
+++ b/static/ai-game-proto.html
@@ -123,6 +123,7 @@
     section {
       padding: 54px 0 8px;
       border-bottom: 1px solid var(--hd-gray-border);
+      scroll-margin-top: 90px;
     }
 
     section:last-of-type {


### PR DESCRIPTION
## Summary\n- Added `scroll-margin-top: 90px` to all `section` elements in `static/ai-game-proto.html`\n- Fixes nav link scrolling where the sticky header was covering the section `h2`\n\nhttps://claude.ai/code/session_01KwbbakStQ6uZXj68wiux6w

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwbbakStQ6uZXj68wiux6w)_